### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/backstopjs.yml
+++ b/.github/workflows/backstopjs.yml
@@ -22,13 +22,7 @@ jobs:
           node-version: 15.x
 
       - name: Install dependencies
-        run: npm install -g backstopjs http-server
-
-      - name: Start the local server
-        run: http-server &
+        run: npm install backstopjs http-server
 
       - name: Run the tests
-        run: backstop test
-
-      - name: Stop the local server
-        run: exit 0
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
 		"start-server": "http-server &",
 		"test": "npm run start-server && backstop test"
 	},
+	"dependencies": {
+		"http-server": "^13"
+	},
 	"devDependencies": {
 		"backstopjs": "^5",
-		"http-server": "^13",
 		"minify": "^7",
 		"rollup": "^2"
 	}


### PR DESCRIPTION
It is better to use npm's script `test` in CI because if it is updated CI is too.

Also, after thinking, I reached the conclusion that http-server is a dependency, not a developement dependency.