### PR TITLE
Add default colors to primitives and lights

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements:
 - Improve performance of cones by ~6x (#64)
 - Improve performance of arrows (#66)
 - Improve performance of cylinders (#67)
+- Add default colors to primitives and lights (#75)
 
 Documentation:
 - Add more examples (#59)

--- a/docs/lights/ambient.md
+++ b/docs/lights/ambient.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 
 Add ambient light to the scene.
 

--- a/docs/lights/directional.md
+++ b/docs/lights/directional.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord](/mathics-threejs-backend/types/coord)) — initial light position in [spherical polar coordinates](https://en.wikipedia.org/wiki/Spherical_coordinate_system)
 
 Add an infinitely far camera-follower light to the scene.

--- a/docs/lights/point.md
+++ b/docs/lights/point.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord](/mathics-threejs-backend/types/coord)) — point coordinates
 
 Add a light that gets emitted from `coords` in all directions to the scene.

--- a/docs/lights/spot.md
+++ b/docs/lights/spot.md
@@ -1,6 +1,6 @@
 Properties:
 - `angle` (type: number) —  the maximum angle in radians of light dispersion (upper bound is pi/2), default: pi/2
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord](/mathics-threejs-backend/types/coord))
 - `target` (type: [coord](/mathics-threejs-backend/types/coord))
 

--- a/docs/primitives/arrow.md
+++ b/docs/primitives/arrow.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: black
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of arrow line-segment coordinates
 - `opacity` (type: number) — default: `1`
 

--- a/docs/primitives/cone.md
+++ b/docs/primitives/cone.md
@@ -1,8 +1,8 @@
 Properties:
-- `color` (type: [color/mathics-threejs-backend/types/color))
+- `color` (type: [color/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord[]/mathics-threejs-backend/types/coord)) — array of cylinders' centers
 - `edgeForm` (type: object) — default: `{}`, object with the following properties:
-  - `color` (type: [color/mathics-threejs-backend/types/color)) — edges' color, default: `[0, 0, 0]` (black edges)
+  - `color` (type: [color/mathics-threejs-backend/types/color)) — edges' color, default: black
   - `showEdges` (type: bool) — default: `true`
 - `radius` (type: number) — default: `1`
 - `opacity` (type: number) — default: `1`

--- a/docs/primitives/cuboid.md
+++ b/docs/primitives/cuboid.md
@@ -1,8 +1,8 @@
 Properties:
-- `color` (type: [color](documentation/types/color))
+- `color` (type: [color](documentation/types/color)) — default: white
 - `coords` (type: [coord[]](documentation/types/coord)) — array of the cuboids' begins and ends
 - `edgeForm` (type: object) — default: `{}`, object with the following properties:
-  - `color` (type: [color](documentation/types/color)) — edges' color, default: `[0, 0, 0]` (black edges)
+  - `color` (type: [color](documentation/types/color)) — edges' color, default: black
   - `showEdges` (type: bool) — default: `true`
 - `opacity` (type: number) — default: `1`
 

--- a/docs/primitives/cylinder.md
+++ b/docs/primitives/cylinder.md
@@ -1,8 +1,8 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of cylinders' centers
 - `edgeForm` (type: object) — default: `{}`, object with the following properties:
-  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: `[0, 0, 0]` (black edges)
+  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: black
   - `showEdges` (type: bool) — default: `true`
 - `radius` (type: number) — default: `1`
 - `opacity` (type: number) — default: `1`

--- a/docs/primitives/line.md
+++ b/docs/primitives/line.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: black
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of line-segment coordinates
 - `dashed` (type: bool) — whether the line is dashed, default: `false`
 - `gapSize` (type: number) — the size of the gaps in pixels, default: `10`

--- a/docs/primitives/point.md
+++ b/docs/primitives/point.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: black
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of each point location
 - `opacity` (type: number) — default: `1`
 - `pointSize` (type: number)

--- a/docs/primitives/polygon.md
+++ b/docs/primitives/polygon.md
@@ -1,13 +1,13 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
-- `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of ordered points tracing the boundary of the polygon
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
+- `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of ordered points tracing the boundary of the polygon, aka. the polygon vertices
 - `edgeForm` (type: object) — default: `{}`, object with the following properties:
-  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: `[0, 0, 0]` (black edges)
+  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: black
   - `showEdges` (type: bool) — default: `true`
 - `opacity` (type: number) — default: `1`
 - `vertexNormals` (type: number[3][]) — this is not commonly used. This changes the way the polygon reflects the light. If this is smaller than the number of total vertexNormals of the polygon, the other vertexNormals are going to be calculated in the shader. See [vertex normal in Wikipedia](https://en.wikipedia.org/wiki/Vertex_normal). Default: `[]`
 
-Draw a polygon with no holes in it, its vertices are `coords`, it can be non-coplanar and non-triangular.
+Draw a polygon with no holes in it, it can be non-coplanar and non-triangular.
 
 ## Examples
 - ```jsonc

--- a/docs/primitives/sphere.md
+++ b/docs/primitives/sphere.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of sphere centers
 - `opacity` (type: number) — default: `1`
 - `radius` (type: number) — default: `1`

--- a/docs/primitives/tube.md
+++ b/docs/primitives/tube.md
@@ -1,5 +1,5 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — draw a tube passing through these coordinates
 - `opacity` (type: number) — default: `1`
 - `radius` (type: number) — default: `1`

--- a/docs/primitives/uniformPolyhedron.md
+++ b/docs/primitives/uniformPolyhedron.md
@@ -1,8 +1,8 @@
 Properties:
-- `color` (type: [color](/mathics-threejs-backend/types/color))
+- `color` (type: [color](/mathics-threejs-backend/types/color)) — default: white
 - `coords` (type: [coord[]](/mathics-threejs-backend/types/coord)) — array of polyhedrons' center
 - `edgeForm` (type: object) — default: `{}`, object with the following properties:
-  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: `[0, 0, 0]` (black edges)
+  - `color` (type: [color](/mathics-threejs-backend/types/color)) — edges' color, default: black
   - `showEdges` (type: bool) — default: `true`
 - `edgeLength` (type: number) — default: `1`
 - `opacity` (type: number) — default: `1`

--- a/src/lights.js
+++ b/src/lights.js
@@ -48,13 +48,13 @@ export function positionLights(lights, theta, phi, focus) {
 }
 
 export default {
-	ambient: ({ color }) => {
+	ambient: ({ color = [1, 1, 1] }) => {
 		return new AmbientLight(new Color(...color).getHex());
 	},
-	directional: ({ color }) => {
+	directional: ({ color = [1, 1, 1] }) => {
 		return new DirectionalLight(new Color(...color).getHex());
 	},
-	spot: ({ angle = 1.57079632679, color, coords, target }, extent) => {
+	spot: ({ angle = 1.57079632679, color = [1, 1, 1], coords, target }, extent) => {
 		const light = new SpotLight(new Color(...color).getHex());
 
 		light.position.set(
@@ -75,7 +75,7 @@ export default {
 
 		return group;
 	},
-	point: ({ color, coords }, extent) => {
+	point: ({ color = [1, 1, 1], coords }, extent) => {
 		const light = new PointLight(new Color(...color).getHex());
 
 		light.position.set(

--- a/src/primitives/arrow.js
+++ b/src/primitives/arrow.js
@@ -15,7 +15,7 @@ import { getBasicMaterial } from '../shader.js';
 
 // See https://reference.wolfram.com/language/ref/Arrow
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, opacity = 1 }, extent) {
+export default function ({ color = [0, 0, 0], coords, opacity = 1 }, extent) {
 	const material = getBasicMaterial(color, opacity);
 
 	const group = new Group();

--- a/src/primitives/cone.js
+++ b/src/primitives/cone.js
@@ -13,7 +13,7 @@ import { get2CoordinatesMaterial } from '../shader.js';
 
 // See https://reference.wolfram.com/language/ref/Cone
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, edgeForm = {}, opacity = 1, radius = 1 }, extent) {
+export default function ({ color = [1, 1, 1], coords, edgeForm = {}, opacity = 1, radius = 1 }, extent) {
 	const [coneBases, coneTips] = get2PopulatedCoordinateBuffers(coords, extent);
 
 	const vertexPosition0 = 0.2588 * radius,

--- a/src/primitives/cuboid.js
+++ b/src/primitives/cuboid.js
@@ -11,7 +11,7 @@ import { get2PopulatedCoordinateBuffers } from '../bufferUtils.js';
 
 // See https://reference.wolfram.com/language/ref/Cuboid
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, edgeForm = {}, opacity = 1 }, extent) {
+export default function ({ color = [1, 1, 1], coords, edgeForm = {}, opacity = 1 }, extent) {
 	// The edges of the cuboids are drawn in the fragment shader; doing this is faster than putting the edges in a different object.
 
 	const [cuboidsBegin, cuboidsEnd] = get2PopulatedCoordinateBuffers(coords, extent);

--- a/src/primitives/cylinder.js
+++ b/src/primitives/cylinder.js
@@ -13,7 +13,7 @@ import { get2CoordinatesMaterial } from '../shader.js';
 
 // See https://reference.wolfram.com/language/ref/Cylinder
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, edgeForm = {}, opacity = 1, radius = 1 }, extent) {
+export default function ({ color = [1, 1, 1], coords, edgeForm = {}, opacity = 1, radius = 1 }, extent) {
 	const [cylindersBegin, cylindersEnd] = get2PopulatedCoordinateBuffers(coords, extent);
 
 	const vertexPosition0 = 0.2588 * radius,

--- a/src/primitives/line.js
+++ b/src/primitives/line.js
@@ -12,7 +12,7 @@ import { getBasicMaterial } from '../shader.js';
 // for the high-level description of what is being rendered.
 // Differently from WL's Line, our lines aren't affected by
 // lightning and therefore don't have VertexNormals.
-export default function ({ color, coords, dashed = false, gapSize = 10, opacity = 1 }, extent, canvasSize) {
+export default function ({ color = [0, 0, 0], coords, dashed = false, gapSize = 10, opacity = 1 }, extent, canvasSize) {
 	return new Line(
 		new BufferGeometry().setAttribute(
 			'position',

--- a/src/primitives/point.js
+++ b/src/primitives/point.js
@@ -11,7 +11,7 @@ import { getPopulatedCoordinateBuffer } from '../bufferUtils.js';
 // for the high-level description of what is being rendered.
 // Differently from WL's Point, our points aren't affected by
 // lightning and therefore don't have VertexNormals.
-export default function ({ color, coords, opacity = 1, pointSize }, extent, canvasSize) {
+export default function ({ color = [0, 0, 0], coords, opacity = 1, pointSize }, extent, canvasSize) {
 	return new Points(
 		new BufferGeometry().setAttribute(
 			'position',

--- a/src/primitives/polygon.js
+++ b/src/primitives/polygon.js
@@ -82,7 +82,7 @@ function getCoplanarityAndNormal(coordinates, extent) {
 
 // See https://reference.wolfram.com/language/ref/Polygon
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, edgeForm = {}, opacity = 1, vertexNormals = {} }, extent) {
+export default function ({ color = [1, 1, 1], coords, edgeForm = {}, opacity = 1, vertexNormals = {} }, extent) {
 	let geometry;
 
 	if (coords.length === 3) { // triangle

--- a/src/primitives/sphere.js
+++ b/src/primitives/sphere.js
@@ -11,7 +11,7 @@ import { getPopulatedCoordinateBuffer } from '../bufferUtils.js';
 
 // See https://reference.wolfram.com/language/ref/Sphere
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
+export default function ({ color = [1, 1, 1], coords, opacity = 1, radius = 1 }, extent) {
 	const sphereGeometry = new InstancedBufferGeometry().copy(
 		new SphereGeometry(radius, 48, 48)
 	);

--- a/src/primitives/tube.js
+++ b/src/primitives/tube.js
@@ -66,7 +66,7 @@ function mergeBufferGeometries(geometries) {
 
 // See https://reference.wolfram.com/language/ref/Tube.html
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
+export default function ({ color = [1, 1, 1], coords, opacity = 1, radius = 1 }, extent) {
 	// TubeGeometry receives a Curve, but Mathics' Tube recives an array of coordinates, so we use CatmullRomCurve3 to convert the coordinates into a Curve.
 	// Curve.getPoint receives a flot between 0 and 1, where 0 is the 1st coordinate and 1 is the last.
 	const curve = new CatmullRomCurve3(

--- a/src/primitives/uniformPolyhedron.js
+++ b/src/primitives/uniformPolyhedron.js
@@ -14,7 +14,7 @@ import { getPopulatedCoordinateBuffer } from '../bufferUtils.js';
 
 // See https://reference.wolfram.com/language/ref/UniformPolyhedron
 // for the high-level description of what is being rendered.
-export default function ({ color, coords, edgeForm = {}, edgeLength = 1, opacity = 1, subType }, extent) {
+export default function ({ color = [1, 1, 1], coords, edgeForm = {}, edgeLength = 1, opacity = 1, subType }, extent) {
 	const polyhedronGeometry = new InstancedBufferGeometry();
 
 	// The magic numbers below are modified from the position attribute of,


### PR DESCRIPTION
Everything except arrow, line and point is white by default, these 3 are black by default.

Linked discussion: #71