### PR TITLE
Simplify lighting structs in shaders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Documentation:
 
 Internals:
 - Update minify to version 8
+- Simplify lighting structs in shaders (#76)
 
 Bug fixes:
 - Correctly calculate the bounding box for primitives with scaled coordinates and radius bigger than the bounding box (#60)

--- a/src/primitives/cuboid.js
+++ b/src/primitives/cuboid.js
@@ -155,69 +155,39 @@ export default function ({ color, coords, edgeForm = {}, opacity = 1 }, extent) 
 					vec3 direction;
 				};
 
-				float getDistanceAttenuation(const in float lightDistance, const in float cutoffDistance, const in float decayExponent) {
-					if (cutoffDistance > 0.0 && decayExponent > 0.0) {
-						return pow(saturate(-lightDistance / cutoffDistance + 1.0), decayExponent);
-					}
-					return 1.0;
-				}
-
 				#if NUM_DIR_LIGHTS > 0
-					struct DirectionalLight {
-						vec3 direction;
-						vec3 color;
-					};
-
-					uniform DirectionalLight directionalLights[NUM_DIR_LIGHTS];
-
-					void getDirectionalLightInfo(const in DirectionalLight directionalLight, out IncidentLight light) {
-						light.color = directionalLight.color;
-						light.direction = directionalLight.direction;
-					}
+					uniform IncidentLight directionalLights[NUM_DIR_LIGHTS];
 				#endif
 				#if NUM_POINT_LIGHTS > 0
 					struct PointLight {
-						vec3 position;
 						vec3 color;
-						float distance;
-						float decay;
+						vec3 position;
 					};
 
 					uniform PointLight pointLights[NUM_POINT_LIGHTS];
 
 					void getPointLightInfo(const in PointLight pointLight, out IncidentLight light) {
-						vec3 lVector = pointLight.position + vViewPosition;
-
-						light.direction = normalize(lVector);
-						light.color = pointLight.color + getDistanceAttenuation(length(lVector), pointLight.distance, pointLight.decay);
+						light.direction = normalize(pointLight.position + vViewPosition);
+						light.color = pointLight.color + 1.0;
 					}
 				#endif
 				#if NUM_SPOT_LIGHTS > 0
 					struct SpotLight {
-						vec3 position;
-						vec3 direction;
 						vec3 color;
-						float distance;
-						float decay;
 						float coneCos;
-						float penumbraCos;
+						vec3 direction;
+						vec3 position;
 					};
-
-					float getSpotAttenuation(const in float coneCosine, const in float penumbraCosine, const in float angleCosine) {
-						return smoothstep(coneCosine, penumbraCosine, angleCosine);
-					}
 
 					uniform SpotLight spotLights[NUM_SPOT_LIGHTS];
 
 					void getSpotLightInfo(const in SpotLight spotLight, out IncidentLight light) {
-						vec3 lVector = spotLight.position + vViewPosition;
-						light.direction = normalize(lVector);
+						light.direction = normalize(spotLight.position + vViewPosition);
 
 						float angleCos = dot(light.direction, spotLight.direction);
-						float spotAttenuation = getSpotAttenuation(spotLight.coneCos, spotLight.penumbraCos, angleCos);
 
-						if (spotAttenuation > 0.0) {
-							light.color = spotLight.color * spotAttenuation + getDistanceAttenuation(length(lVector), spotLight.distance, spotLight.decay);
+						if (angleCos > 0.0) {
+							light.color = spotLight.color * angleCos + 1.0;
 						} else {
 							light.color = vec3(0.0);
 						}
@@ -247,27 +217,21 @@ export default function ({ color, coords, edgeForm = {}, opacity = 1 }, extent) 
 					vec3 reflectedLight = vec3(0.0);
 
 					IncidentLight directLight;
+
+					#if NUM_DIR_LIGHTS > 0
+						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+							reflectedLight += RE_Direct(directionalLights[i], normal, diffuseColor);
+						}
+					#endif
 					#if NUM_POINT_LIGHTS > 0
-						PointLight pointLight;
 						for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
-							pointLight = pointLights[i];
-							getPointLightInfo(pointLight, directLight);
+							getPointLightInfo(pointLights[i], directLight);
 							reflectedLight += RE_Direct(directLight, normal, diffuseColor);
 						}
 					#endif
 					#if NUM_SPOT_LIGHTS > 0
-						SpotLight spotLight;
 						for (int i = 0; i < NUM_SPOT_LIGHTS; i++) {
-							spotLight = spotLights[i];
-							getSpotLightInfo(spotLight, directLight);
-							reflectedLight += RE_Direct(directLight, normal, diffuseColor);
-						}
-					#endif
-					#if NUM_DIR_LIGHTS > 0
-						DirectionalLight directionalLight;
-						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
-							directionalLight = directionalLights[i];
-							getDirectionalLightInfo(directionalLight, directLight);
+							getSpotLightInfo(spotLights[i], directLight);
 							reflectedLight += RE_Direct(directLight, normal, diffuseColor);
 						}
 					#endif

--- a/src/primitives/polygon.js
+++ b/src/primitives/polygon.js
@@ -207,71 +207,35 @@ export default function ({ color, coords, edgeForm = {}, opacity = 1, vertexNorm
 					vec3 direction;
 				};
 
-				float getDistanceAttenuation(const in float lightDistance, const in float cutoffDistance, const in float decayExponent) {
-					if (cutoffDistance > 0.0 && decayExponent > 0.0) {
-						return pow(saturate(-lightDistance / cutoffDistance + 1.0), decayExponent);
-					}
-					return 1.0;
-				}
-
-				float getSpotAttenuation(const in float coneCosine, const in float penumbraCosine, const in float angleCosine) {
-					return smoothstep(coneCosine, penumbraCosine, angleCosine);
-				}
-
 				#if NUM_DIR_LIGHTS > 0
-					struct DirectionalLight {
-						vec3 direction;
-						vec3 color;
-					};
-
-					uniform DirectionalLight directionalLights[NUM_DIR_LIGHTS];
-
-					void getDirectionalLightInfo(const in DirectionalLight directionalLight, out IncidentLight light) {
-						light.color = directionalLight.color;
-						light.direction = directionalLight.direction;
-					}
+					uniform IncidentLight directionalLights[NUM_DIR_LIGHTS];
 				#endif
 				#if NUM_POINT_LIGHTS > 0
 					struct PointLight {
-						vec3 position;
 						vec3 color;
-						float distance;
-						float decay;
+						vec3 position;
 					};
 
 					uniform PointLight pointLights[NUM_POINT_LIGHTS];
 
 					void getPointLightInfo(const in PointLight pointLight, out IncidentLight light) {
-						vec3 lVector = pointLight.position + vViewPosition;
-						light.direction = normalize(lVector);
-						float lightDistance = length(lVector);
-						light.color = pointLight.color * getDistanceAttenuation(lightDistance, pointLight.distance, pointLight.decay);
+						light.direction = normalize(pointLight.position + vViewPosition);
+						light.color = pointLight.color;
 					}
 				#endif
 				#if NUM_SPOT_LIGHTS > 0
 					struct SpotLight {
-						vec3 position;
-						vec3 direction;
 						vec3 color;
-						float distance;
-						float decay;
 						float coneCos;
-						float penumbraCos;
+						vec3 direction;
+						vec3 position;
 					};
 
 					uniform SpotLight spotLights[NUM_SPOT_LIGHTS];
 
 					void getSpotLightInfo(const in SpotLight spotLight, out IncidentLight light) {
-						vec3 lVector = spotLight.position + vViewPosition;
-						light.direction = normalize(lVector);
-						float angleCos = dot(light.direction, spotLight.direction);
-						float spotAttenuation = getSpotAttenuation(spotLight.coneCos, spotLight.penumbraCos, angleCos);
-						if (spotAttenuation > 0.0) {
-							float lightDistance = length(lVector);
-							light.color = spotLight.color * spotAttenuation * getDistanceAttenuation(lightDistance, spotLight.distance, spotLight.decay);
-						} else {
-							light.color = vec3(0.0);
-						}
+						light.direction = normalize(spotLight.position + vViewPosition);
+						light.color = spotLight.color * max(dot(light.direction, spotLight.direction), 0.0);
 					}
 				#endif
 
@@ -289,27 +253,20 @@ export default function ({ color, coords, edgeForm = {}, opacity = 1, vertexNorm
 
 					IncidentLight directLight;
 
+					#if NUM_DIR_LIGHTS > 0
+						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+							reflectedLight += RE_Direct(directionalLights[i], normal);
+						}
+					#endif
 					#if NUM_POINT_LIGHTS > 0
-						PointLight pointLight;
 						for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
-							pointLight = pointLights[i];
-							getPointLightInfo(pointLight, directLight);
+							getPointLightInfo(pointLights[i], directLight);
 							reflectedLight += RE_Direct(directLight, normal);
 						}
 					#endif
 					#if NUM_SPOT_LIGHTS > 0
-						SpotLight spotLight;
 						for (int i = 0; i < NUM_SPOT_LIGHTS; i++) {
-							spotLight = spotLights[i];
-							getSpotLightInfo(spotLight, directLight);
-							reflectedLight += RE_Direct(directLight, normal);
-						}
-					#endif
-					#if NUM_DIR_LIGHTS > 0
-						DirectionalLight directionalLight;
-						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
-							directionalLight = directionalLights[i];
-							getDirectionalLightInfo(directionalLight, directLight);
+							getSpotLightInfo(spotLight, spotLights[i]);
 							reflectedLight += RE_Direct(directLight, normal);
 						}
 					#endif

--- a/src/primitives/sphere.js
+++ b/src/primitives/sphere.js
@@ -60,74 +60,35 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 					vec3 normal;
 				};
 
-				float getDistanceAttenuation(const in float lightDistance, const in float cutoffDistance, const in float decayExponent) {
-					if (cutoffDistance > 0.0 && decayExponent > 0.0) {
-						return pow(saturate(- lightDistance / cutoffDistance + 1.0), decayExponent);
-					}
-					return 1.0;
-				}
-
 				#if NUM_DIR_LIGHTS > 0
-					struct DirectionalLight {
-						vec3 direction;
-						vec3 color;
-					};
-
-					uniform DirectionalLight directionalLights[NUM_DIR_LIGHTS];
-
-					void getDirectionalLightInfo(const in DirectionalLight directionalLight, out IncidentLight light) {
-						light.color = directionalLight.color;
-						light.direction = directionalLight.direction;
-					}
+					uniform IncidentLight directionalLights[NUM_DIR_LIGHTS];
 				#endif
 				#if NUM_POINT_LIGHTS > 0
 					struct PointLight {
-						vec3 position;
 						vec3 color;
-						float distance;
-						float decay;
+						vec3 position;
 					};
 
 					uniform PointLight pointLights[NUM_POINT_LIGHTS];
 
 					void getPointLightInfo(const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight light) {
-						vec3 lVector = pointLight.position - geometry.position;
-
-						light.direction = normalize(lVector);
-						light.color = pointLight.color * getDistanceAttenuation(length(lVector), pointLight.distance, pointLight.decay);
+						light.direction = normalize(pointLight.position - geometry.position);
+						light.color = pointLight.color;
 					}
 				#endif
 				#if NUM_SPOT_LIGHTS > 0
 					struct SpotLight {
-						vec3 position;
-						vec3 direction;
 						vec3 color;
-						float distance;
-						float decay;
 						float coneCos;
-						float penumbraCos;
+						vec3 direction;
+						vec3 position;
 					};
 
 					uniform SpotLight spotLights[NUM_SPOT_LIGHTS];
 
-					float getSpotAttenuation(const in float coneCosine, const in float penumbraCosine, const in float angleCosine) {
-						return smoothstep(coneCosine, penumbraCosine, angleCosine);
-					}
-
 					void getSpotLightInfo(const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight light) {
-						vec3 lVector = spotLight.position - geometry.position;
-
-						light.direction = normalize(lVector);
-
-						float angleCos = dot(light.direction, spotLight.direction);
-
-						float spotAttenuation = getSpotAttenuation(spotLight.coneCos, spotLight.penumbraCos, angleCos);
-
-						if (spotAttenuation > 0.0) {
-							light.color = spotLight.color * spotAttenuation * getDistanceAttenuation(length(lVector), spotLight.distance, spotLight.decay);
-						} else {
-							light.color = vec3(0.0);
-						}
+						light.direction = normalize(spotLight.position - geometry.position);
+						light.color = spotLight.color * max(dot(light.direction, spotLight.direction), 0.0);
 					}
 				#endif
 
@@ -145,6 +106,11 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 
 					IncidentLight directLight;
 
+					#if NUM_DIR_LIGHTS > 0
+						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+							light += saturate(dot(geometry.normal, directionalLights[i].direction)) * directionalLights[i].color;
+						}
+					#endif
 					#if NUM_POINT_LIGHTS > 0
 						for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
 							getPointLightInfo(pointLights[i], geometry, directLight);
@@ -155,13 +121,6 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 					#if NUM_SPOT_LIGHTS > 0
 						for (int i = 0; i < NUM_SPOT_LIGHTS; i++) {
 							getSpotLightInfo(spotLights[i], geometry, directLight);
-
-							light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
-						}
-					#endif
-					#if NUM_DIR_LIGHTS > 0
-						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
-							getDirectionalLightInfo(directionalLights[i], directLight);
 
 							light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
 						}

--- a/src/primitives/tube.js
+++ b/src/primitives/tube.js
@@ -146,71 +146,39 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 					vec3 normal;
 				};
 
-				float getDistanceAttenuation(const in float lightDistance, const in float cutoffDistance, const in float decayExponent) {
-					if (cutoffDistance > 0.0 && decayExponent > 0.0) {
-						return pow(saturate(- lightDistance / cutoffDistance + 1.0), decayExponent);
-					}
-					return 1.0;
-				}
-
 				#if NUM_DIR_LIGHTS > 0
-					struct DirectionalLight {
-						vec3 direction;
-						vec3 color;
-					};
-
-					uniform DirectionalLight directionalLights[NUM_DIR_LIGHTS];
-
-					void getDirectionalLightInfo(const in DirectionalLight directionalLight, out IncidentLight light) {
-						light.color = directionalLight.color;
-						light.direction = directionalLight.direction;
-					}
+					uniform IncidentLight directionalLights[NUM_DIR_LIGHTS];
 				#endif
 				#if NUM_POINT_LIGHTS > 0
 					struct PointLight {
-						vec3 position;
 						vec3 color;
-						float distance;
-						float decay;
+						vec3 position;
 					};
 
 					uniform PointLight pointLights[NUM_POINT_LIGHTS];
 
 					void getPointLightInfo(const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight light) {
-						vec3 lVector = pointLight.position - geometry.position;
-
-						light.direction = normalize(lVector);
-						light.color = pointLight.color * getDistanceAttenuation(length(lVector), pointLight.distance, pointLight.decay);
+						light.direction = normalize(pointLight.position - geometry.position);
+						light.color = pointLight.color;
 					}
 				#endif
 				#if NUM_SPOT_LIGHTS > 0
 					struct SpotLight {
-						vec3 position;
-						vec3 direction;
 						vec3 color;
-						float distance;
-						float decay;
 						float coneCos;
-						float penumbraCos;
+						vec3 direction;
+						vec3 position;
 					};
 
 					uniform SpotLight spotLights[NUM_SPOT_LIGHTS];
 
-					float getSpotAttenuation(const in float coneCosine, const in float penumbraCosine, const in float angleCosine) {
-						return smoothstep(coneCosine, penumbraCosine, angleCosine);
-					}
-
 					void getSpotLightInfo(const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight light) {
-						vec3 lVector = spotLight.position - geometry.position;
-
-						light.direction = normalize(lVector);
+						light.direction = normalize(spotLight.position - geometry.position);
 
 						float angleCos = dot(light.direction, spotLight.direction);
 
-						float spotAttenuation = getSpotAttenuation(spotLight.coneCos, spotLight.penumbraCos, angleCos);
-
-						if (spotAttenuation > 0.0) {
-							light.color = spotLight.color * spotAttenuation * getDistanceAttenuation(length(lVector), spotLight.distance, spotLight.decay);
+						if (angleCos > 0.0) {
+							light.color = spotLight.color * max(dot(light.direction, spotLight.direction), 0.0);
 						} else {
 							light.color = vec3(0.0);
 						}
@@ -231,6 +199,11 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 
 					IncidentLight directLight;
 
+					#if NUM_DIR_LIGHTS > 0
+						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+							light += saturate(dot(geometry.normal, directionalLights[i].direction)) * directionalLights[i].color;
+						}
+					#endif
 					#if NUM_POINT_LIGHTS > 0
 						for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
 							getPointLightInfo(pointLights[i], geometry, directLight);
@@ -241,13 +214,6 @@ export default function ({ color, coords, opacity = 1, radius = 1 }, extent) {
 					#if NUM_SPOT_LIGHTS > 0
 						for (int i = 0; i < NUM_SPOT_LIGHTS; i++) {
 							getSpotLightInfo(spotLights[i], geometry, directLight);
-
-							light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
-						}
-					#endif
-					#if NUM_DIR_LIGHTS > 0
-						for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
-							getDirectionalLightInfo(directionalLights[i], directLight);
 
 							light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
 						}

--- a/src/shader.js
+++ b/src/shader.js
@@ -40,74 +40,35 @@ export function get2CoordinatesMaterial(color, opacity) {
 				vec3 normal;
 			};
 
-			float getDistanceAttenuation(const in float lightDistance, const in float cutoffDistance, const in float decayExponent) {
-				if (cutoffDistance > 0.0 && decayExponent > 0.0) {
-					return pow(saturate(- lightDistance / cutoffDistance + 1.0), decayExponent);
-				}
-				return 1.0;
-			}
-
 			#if NUM_DIR_LIGHTS > 0
-				struct DirectionalLight {
-					vec3 direction;
-					vec3 color;
-				};
-
-				uniform DirectionalLight directionalLights[NUM_DIR_LIGHTS];
-
-				void getDirectionalLightInfo(const in DirectionalLight directionalLight, out IncidentLight light) {
-					light.color = directionalLight.color;
-					light.direction = directionalLight.direction;
-				}
+				uniform IncidentLight directionalLights[NUM_DIR_LIGHTS];
 			#endif
 			#if NUM_POINT_LIGHTS > 0
 				struct PointLight {
-					vec3 position;
 					vec3 color;
-					float distance;
-					float decay;
+					vec3 position;
 				};
 
 				uniform PointLight pointLights[NUM_POINT_LIGHTS];
 
 				void getPointLightInfo(const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight light) {
-					vec3 lVector = pointLight.position - geometry.position;
-
-					light.direction = normalize(lVector);
-					light.color = pointLight.color * getDistanceAttenuation(length(lVector), pointLight.distance, pointLight.decay);
+					light.direction = normalize(pointLight.position - geometry.position);
+					light.color = pointLight.color;
 				}
 			#endif
 			#if NUM_SPOT_LIGHTS > 0
 				struct SpotLight {
-					vec3 position;
-					vec3 direction;
 					vec3 color;
-					float distance;
-					float decay;
 					float coneCos;
-					float penumbraCos;
+					vec3 direction;
+					vec3 position;
 				};
 
 				uniform SpotLight spotLights[NUM_SPOT_LIGHTS];
 
-				float getSpotAttenuation(const in float coneCosine, const in float penumbraCosine, const in float angleCosine) {
-					return smoothstep(coneCosine, penumbraCosine, angleCosine);
-				}
-
 				void getSpotLightInfo(const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight light) {
-					vec3 lVector = spotLight.position - geometry.position;
-
-					light.direction = normalize(lVector);
-
-					float angleCos = dot(light.direction, spotLight.direction);
-
-					float spotAttenuation = getSpotAttenuation(spotLight.coneCos, spotLight.penumbraCos, angleCos);
-
-					if (spotAttenuation > 0.0) {
-						light.color = spotLight.color * spotAttenuation * getDistanceAttenuation(length(lVector), spotLight.distance, spotLight.decay);
-					} else {
-						light.color = vec3(0.0);
-					}
+					light.direction = normalize(spotLight.position - geometry.position);
+					light.color = spotLight.color * max(dot(light.direction, spotLight.direction), 0.0);
 				}
 			#endif
 
@@ -142,6 +103,11 @@ export function get2CoordinatesMaterial(color, opacity) {
 
 				IncidentLight directLight;
 
+				#if NUM_DIR_LIGHTS > 0
+					for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
+						light += saturate(dot(geometry.normal, directionalLights[i].direction)) * directionalLights[i].color;
+					}
+				#endif
 				#if NUM_POINT_LIGHTS > 0
 					for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
 						getPointLightInfo(pointLights[i], geometry, directLight);
@@ -152,13 +118,6 @@ export function get2CoordinatesMaterial(color, opacity) {
 				#if NUM_SPOT_LIGHTS > 0
 					for (int i = 0; i < NUM_SPOT_LIGHTS; i++) {
 						getSpotLightInfo(spotLights[i], geometry, directLight);
-
-						light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
-					}
-				#endif
-				#if NUM_DIR_LIGHTS > 0
-					for (int i = 0; i < NUM_DIR_LIGHTS; i++) {
-						getDirectionalLightInfo(directionalLights[i], directLight);
 
 						light += saturate(dot(geometry.normal, directLight.direction)) * directLight.color;
 					}


### PR DESCRIPTION
This is possible because the values of `penumbraCos`, `distance` and `decay` were always the same.